### PR TITLE
Fix INFO and MACOSX_VERSION_MIN keys in Info.plist

### DIFF
--- a/installers/mac/tar/build.gradle
+++ b/installers/mac/tar/build.gradle
@@ -100,12 +100,12 @@ task prepareArtifacts {
 
         // Replace Info.plist
         def plistTokens = new Properties()
-        plistTokens["INFO"] = "Amazon Corretto ${project.version.full}-LTS".toString()
+        plistTokens["INFO"] = "Amazon Corretto ${project.version.full}-${versionOpt}".toString()
         plistTokens["ID"] = "com.amazon.corretto.${project.version.major}".toString()
         plistTokens["NAME"] = "Amazon Corretto ${project.version.major}".toString()
         plistTokens["VERSION"] = "${project.version.major}.${project.version.minor}.${project.version.security}".toString()
         plistTokens["BUILD_VERSION"] = "${project.version.full}".toString()
-        plistTokens["MACOSX_VERSION_MIN"] = "10.6.0"
+        plistTokens["MACOSX_VERSION_MIN"] = (correttoArch == "x64" ? "10.12" : "11.0")
         plistTokens["VENDOR"] = "Amazon.com Inc."
 
         copy {


### PR DESCRIPTION
After change:

```
        <key>CFBundleGetInfoString</key>
        <string>Amazon Corretto 18.0.0.35.1-FR</string>
```

```
                <key>JVMMinimumSystemVersion</key>
                <string>10.12</string>
```