### PR TITLE
Revert "update upstream branch to jdk18u"

### DIFF
--- a/.github/workflows/refresh-jdk.yml
+++ b/.github/workflows/refresh-jdk.yml
@@ -4,7 +4,7 @@ on:
     - cron: '0 8 * * *'
   workflow_dispatch:
 env:
-  UPSTREAM_REMOTE: https://github.com/openjdk/jdk18u
+  UPSTREAM_REMOTE: https://github.com/openjdk/jdk18
   LOCAL_BRANCH: develop
 jobs:
     refresh-jdk:


### PR DESCRIPTION
This reverts commit [eb314f3ea7c25e3bcaf9a006a99d83220546a802](https://github.com/corretto/corretto-18/commit/eb314f3ea7c25e3bcaf9a006a99d83220546a802).

The latest commit to that branch is for 18.0.2
https://bugs.openjdk.java.net/browse/JDK-8284436