### PR TITLE
Fix src.rpm name that some tools depend on

### DIFF
--- a/installers/linux/universal/rpm/build.gradle
+++ b/installers/linux/universal/rpm/build.gradle
@@ -103,6 +103,9 @@ task generateJdkRpm(type: Rpm) {
     packageDescription packageInfo.description
     summary "Amazon Corretto ${project.version.major} development environment"
     packageGroup 'Development/Tools'
+    // Remove after https://github.com/nebula-plugins/gradle-ospackage-plugin/issues/401 is merged and released
+    sourcePackage "${jdkPackageName}-${project.version.major}.${project.version.minor}.${project.version.security}.${project.version.build}-${project.version.revision}.src.rpm"
+
     prefix(jdkHome)
     postInstall file("$buildRoot/scripts/postin_java.sh")
     postInstall file("$buildRoot/scripts/postin_javac.sh")


### PR DESCRIPTION
backport of https://github.com/corretto/corretto-jdk/commit/aa06ddb1a1b7b9e24c8f18d221f5d01698149de4